### PR TITLE
Add LDAP settings update script for LemonLDAP-ng integration

### DIFF
--- a/imageroot/bin/update-ldap-settings
+++ b/imageroot/bin/update-ldap-settings
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+import agent
+import sys
+
+schema = agent.read_envfile("discovery_ldap.env ").get("LDAP_SCHEMA", "")
+ldap_base = agent.read_envfile("discovery_ldap.env ").get("LDAP_BASE", "")
+ldap_pass = agent.read_envfile("discovery_ldap.env ").get("LDAP_PASS", "")
+ldap_host = "10.0.2.2"
+ldap_user = agent.read_envfile("discovery_ldap.env ").get("LDAP_USER", "")
+ldap_port = agent.read_envfile("discovery_ldap.env ").get("LDAP_PORT", "")
+
+if ldap_pass == "invalid":
+    print ("LDAP settings are invalid", file=sys.stderr)
+    sys.exit(0)
+
+if schema == "rfc2307":
+    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "authentication" "LDAP", "passwordDB", "LDAP", "userDB", "Same", "registerDB", "Null", "ldapServer", "ldap://" + ldap_host+':'+ldap_port, "ldapVerify", "none", "ldapBase", ldap_base , "managerDn",  ldap_user, "managerPassword", ldap_pass, "ldapGroupBase", "ou=Groups,"+ ldap_base, "ldapGroupObjectClass", "posixGroup")
+    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "ldapExportedVars", "uid", "uid", "ldapExportedVars", "cn", "cn", "ldapExportedVars", "mail", "Email")
+
+#[root@ns1 ~]# perl test
+#dc=directory,dc=nhldap://127.0.0.1ou=Groups,dc=directory,dc=nh[root@ns1 ~]# 
+#dc=directory,dc=nhldap://127.0.0.1ou=Groups,dc=directory,dc=nhcn=ldapservice,dc=directory,dc=nhdc=directory,dc=nhfWMJaAk8v_uuoSzS[root@ns1 ~]# 

--- a/imageroot/systemd/user/lemonldapng-app.service
+++ b/imageroot/systemd/user/lemonldapng-app.service
@@ -48,6 +48,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lemonldapng-app.pid \
         --volume ./llng/menutab:/usr/share/perl5/Lemonldap/NG/Portal/MenuTab/CustomMenuTab:Z \
     ${LEMONLDAP_NG_IMAGE}
 ExecStartPost=/usr/local/bin/runagent update-smtp-settings
+ExecStartPost=/usr/local/bin/runagent update-ldap-settings
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/lemonldapng-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP lemonldapng-app
 SyslogIdentifier=%u


### PR DESCRIPTION
Introduce a script to update LDAP settings and integrate with the LemonLDAP-ng service, enhancing the application's authentication capabilities. Update the service configuration to execute this script during startup.