### PR TITLE
Update image labels and enhance preserve files in LemonLDAP-ng service

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -39,7 +39,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm cluster:accountconsumer" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/lemonldapng/lemonldap-ng:2.20.2" \
+    --label="org.nethserver.images=docker.io/coudot/lemonldap-ng:2.20.2" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/bin/update-smtp-settings
+++ b/imageroot/bin/update-smtp-settings
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 import agent
+import subprocess
 
 enabled = agent.read_envfile("smarthost.env").get("SMTP_ENABLED", "")
 SMTPAuthPass = agent.read_envfile("smarthost.env").get("SMTP_PASSWORD", "")
@@ -13,7 +14,10 @@ SMTPServer = agent.read_envfile("smarthost.env").get("SMTP_HOST", "")
 SMTPTLS = agent.read_envfile("smarthost.env").get("SMTP_ENCRYPTION", "")
 SMTPPort = agent.read_envfile("smarthost.env").get("SMTP_PORT", "")
 
+
 if enabled == "1":
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "SMTPAuthPass", SMTPAuthPass, "SMTPAuthUser", SMTPAuthUser, "SMTPServer", SMTPServer, "SMTPTLS", SMTPTLS, "SMTPPort" , SMTPPort)
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "SMTPAuthPass", SMTPAuthPass, "SMTPAuthUser", SMTPAuthUser, "SMTPServer", SMTPServer, "SMTPTLS", SMTPTLS, "SMTPPort", SMTPPort]
 else:
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "del", "SMTPAuthPass", "SMTPAuthUser", "SMTPServer", "SMTPTLS", "SMTPPort")
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "del", "SMTPAuthPass", "SMTPAuthUser", "SMTPServer", "SMTPTLS", "SMTPPort"]
+
+subprocess.run(command, stderr=subprocess.DEVNULL, check=True)

--- a/imageroot/systemd/user/lemonldapng-app.service
+++ b/imageroot/systemd/user/lemonldapng-app.service
@@ -30,7 +30,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lemonldapng-app.pid \
         --env HANDLER_HOSTNAME=reload.${TRAEFIK_HOST} \
         --env TEST1_HOSTNAME=test1.${TRAEFIK_HOST} \
         --env TEST2_HOSTNAME=test2.${TRAEFIK_HOST} \
-        --env PRESERVEFILES="/etc/lemonldap-ng /var/lib/lemonldap-ng/conf /var/lib/lemonldap-ng/sessions /var/lib/lemonldap-ng/psessions" \
+        --env PRESERVEFILES="/etc/lemonldap-ng /var/lib/lemonldap-ng/conf /var/lib/lemonldap-ng/sessions /var/lib/lemonldap-ng/psessions /etc/nginx/sites-enabled" \
         --env LOGLEVEL=error \
         --env FASTCGI_LISTEN_PORT=9000 \
         --env PORT=80 \
@@ -38,6 +38,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lemonldapng-app.pid \
         --volume var-conf:/var/lib/lemonldap-ng/conf:Z \
         --volume var-sessions:/var/lib/lemonldap-ng/sessions:Z \
         --volume var-psessions:/var/lib/lemonldap-ng/psessions:Z \
+        --volume nginx:/etc/nginx/sites-enabled:Z \
         --volume ./llng/theme:/usr/share/lemonldap-ng/portal/htdocs/static/CustomTheme:Z \
         --volume ./llng/template:/usr/share/lemonldap-ng/portal/templates/CustomTheme:Z \
         --volume ./llng/plugins:/usr/share/perl5/Lemonldap/NG/Portal/Plugins/CustomPlugin:Z \


### PR DESCRIPTION
Configuration updates:

* [`build-images.sh`](diffhunk://#diff-abc769369f8124f5745e9ea8898f7989a1b1458439d50214f955690520421902L42-R42): Changed the image label to reference a different Docker image for LemonLDAP::NG.

Environment and volume updates:

* [`imageroot/systemd/user/lemonldapng-app.service`](diffhunk://#diff-815c7d4ed364bca4f16ae26482d7b39a18a54553fc9bbee459e79e861276c908L33-R41): Added a new environment variable to preserve files in `/etc/nginx/sites-enabled` and included a corresponding volume mapping for this directory.Change the image label to use a different repository and add an additional directory to the preserve files environment variable for the LemonLDAP-ng service.