### PR TITLE
Refactor LDAP settings update to use subprocess for command execution

### DIFF
--- a/imageroot/bin/update-ldap-settings
+++ b/imageroot/bin/update-ldap-settings
@@ -7,6 +7,7 @@
 import agent
 import sys
 import os
+import subprocess
 
 schema = agent.read_envfile("discovery_ldap.env").get("LDAP_SCHEMA", "")
 ldap_base = agent.read_envfile("discovery_ldap.env").get("LDAP_BASE", "")
@@ -20,14 +21,35 @@ if ldap_pass == "invalid":
     sys.exit(0)
 
 if schema == "rfc2307":
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "authentication", "LDAP", "passwordDB", "LDAP", "userDB", "LDAP", "registerDB", "Null", "ldapServer", "ldap://" + ldap_host+':'+ldap_port, "ldapVerify", "none", "ldapBase", ldap_base , "managerDn",  ldap_user, "managerPassword", ldap_pass)
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "ldapGroupBase", "ou=Groups,"+ ldap_base, "ldapGroupObjectClass", "posixGroup", "groupLDAPFilter", "(objectClass=posixGroup)","ldapGroupAttributeName", "memberUid", "ldapGroupAttributeNameUser", "uid", "ldapGroupAttributeNameSearch", "cn", "ldapGroupRecursive", "1", "ldapGroupAttributeNameGroup", "dn")
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "ldapExportedVars", "uid", "uid", "ldapExportedVars", "cn", "cn", "ldapExportedVars", "mail", "mail")
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "delKey", "locationRules/", "manager."+os.environ['TRAEFIK_HOST'])
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "locationRules/manager."+os.environ['TRAEFIK_HOST'], "default", '$uid eq administrator or inGroup("domain admins")')
+    print ("Setting LDAP settings for RFC2307 schema", file=sys.stderr)
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "authentication", "LDAP", "passwordDB", "LDAP", "userDB", "LDAP", "registerDB", "Null", "ldapServer", "ldap://" + ldap_host+':'+ldap_port, "ldapVerify", "none", "ldapBase", ldap_base , "managerDn",  ldap_user, "managerPassword", ldap_pass]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "ldapGroupBase", "ou=Groups,"+ ldap_base, "ldapGroupObjectClass", "posixGroup", "groupLDAPFilter", "(objectClass=posixGroup)","ldapGroupAttributeName", "memberUid", "ldapGroupAttributeNameUser", "uid", "ldapGroupAttributeNameSearch", "cn", "ldapGroupRecursive", "1", "ldapGroupAttributeNameGroup", "dn"]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "ldapExportedVars", "uid", "uid", "ldapExportedVars", "cn", "cn", "ldapExportedVars", "mail", "mail"]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "delKey", "locationRules/", "manager."+os.environ['TRAEFIK_HOST']]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "locationRules/manager."+os.environ['TRAEFIK_HOST'], "default", '$uid eq administrator or inGroup("domain admins")']
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
 elif schema == "ad":
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "authentication", "AD", "passwordDB", "AD", "userDB", "AD", "registerDB", "Null", "ldapServer", "ldap://" + ldap_host+':'+ldap_port, "ldapVerify", "none", "ldapBase", ldap_base , "managerDn",  ldap_user, "managerPassword", ldap_pass)
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "ldapGroupBase", ldap_base, "ldapGroupObjectClass", "group", "groupLDAPFilter", "(objectClass=group)","ldapGroupAttributeName", "member", "ldapGroupAttributeNameUser", "dn", "ldapGroupAttributeNameSearch", "cn", "ldapGroupRecursive", "1", "ldapGroupDecodeSearchedValue", "1", "ldapGroupAttributeNameGroup", "dn")
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "ldapExportedVars", "uid", "sAMAccountName", "ldapExportedVars", "cn", "displayName", "ldapExportedVars", "mail", "mail")
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "delKey", "locationRules/", "manager."+os.environ['TRAEFIK_HOST'])
-    agent.run_helper("podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "locationRules/manager."+os.environ['TRAEFIK_HOST'], "default", '$uid eq administrator or inGroup("domain admins")')
+    print ("Setting LDAP settings for AD schema", file=sys.stderr)
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "authentication", "AD", "passwordDB", "AD", "userDB", "AD", "registerDB", "Null", "ldapServer", "ldap://" + ldap_host+':'+ldap_port, "ldapVerify", "none", "ldapBase", ldap_base , "managerDn",  ldap_user, "managerPassword", ldap_pass]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "set", "ldapGroupBase", ldap_base, "ldapGroupObjectClass", "group", "groupLDAPFilter", "(objectClass=group)","ldapGroupAttributeName", "member", "ldapGroupAttributeNameUser", "dn", "ldapGroupAttributeNameSearch", "cn", "ldapGroupRecursive", "1", "ldapGroupDecodeSearchedValue", "1", "ldapGroupAttributeNameGroup", "dn"]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "ldapExportedVars", "uid", "sAMAccountName", "ldapExportedVars", "cn", "displayName", "ldapExportedVars", "mail", "mail"]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "delKey", "locationRules/", "manager."+os.environ['TRAEFIK_HOST']]
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)
+
+    command = ["podman", "exec", "lemonldapng-app", "/usr/share/lemonldap-ng/bin/lemonldap-ng-cli", "-yes", "1", "addKey", "locationRules/manager."+os.environ['TRAEFIK_HOST'], "default", '$uid eq administrator or inGroup("domain admins")']
+    subprocess.run(command, stderr=subprocess.DEVNULL, check=True)


### PR DESCRIPTION
Replace the existing method of executing LDAP settings updates with subprocess calls for improved reliability and error handling. This change enhances the execution of commands within the LDAP settings update process.