### PR TITLE
Enhance Traefik configuration and update service setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `./llng` folder within the state directory stores customizations such as the
 
 ```
 ./llng/
+├── apps
 ├── auth
 ├── captcha
 ├── menutab

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -7,14 +7,16 @@
         {
             "host": "lemonldapng.domain.org",
             "http2https": true,
-            "lets_encrypt": true
+            "lets_encrypt": true,
+            "ldap_domain": "domain.org"
         }
     ],
     "type": "object",
     "required": [
         "host",
         "http2https",
-        "lets_encrypt"
+        "lets_encrypt",
+        "ldap_domain"
     ],
     "properties": {
         "host": {
@@ -32,6 +34,13 @@
             "type": "boolean",
             "title": "HTTP to HTTPS redirection",
             "description": "Redirect all the HTTP requests to HTTPS"
+        },
+        "ldap_domain": {
+            "type": "string",
+            "title": "LDAP domain",
+            "description": "Choose the LDAP domain to authenticate users",
+            "format": "hostname",
+            "pattern": "\\."
         }
     }
 }

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -20,6 +20,8 @@ config = {}
 
 # Read current configuration from the environment file
 config["host"] = os.getenv("TRAEFIK_HOST","")
+config["configured"] = True if config["host"] else False
+config["http_port"] = os.getenv("TRAEFIK_HTTP_PORT", "80")
 config["http2https"] = os.getenv("TRAEFIK_HTTP2HTTPS") == "True"
 config["lets_encrypt"] = os.getenv("TRAEFIK_LETS_ENCRYPT") == "True"
 

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -7,14 +7,18 @@
         {
             "host": "lemonldapng.domain.org",
             "http2https": true,
-            "lets_encrypt": true
+            "lets_encrypt": true,
+            "ldap_domain": "domain.org",
+            "configured": true
         }
     ],
     "type": "object",
     "required": [
         "host",
         "http2https",
-        "lets_encrypt"
+        "lets_encrypt",
+        "ldap_domain",
+        "configured"
     ],
     "properties": {
         "host": {
@@ -31,6 +35,16 @@
             "type": "boolean",
             "title": "HTTP to HTTPS redirection",
             "description": "Redirect all the HTTP requests to HTTPS"
+        },
+        "ldap_domain": {
+            "type": "string",
+            "title": "LDAP domain",
+            "description": "Choose the LDAP domain to authenticate users"
+        },
+        "configured": {
+            "type": "boolean",
+            "title": "Configured",
+            "description": "True if the application is already configured"
         }
     }
 }

--- a/imageroot/systemd/user/lemonldapng-app.service
+++ b/imageroot/systemd/user/lemonldapng-app.service
@@ -17,7 +17,7 @@ WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/lemonldapng-app.pid %t/lemonldapng-app.ctr-id
-ExecStartPre=/bin/bash -c '/bin/mkdir -p ./llng/{theme,template,plugins,register,userdb,auth,captcha,menutab}'
+ExecStartPre=/bin/bash -c '/bin/mkdir -p ./llng/{theme,template,plugins,register,userdb,auth,captcha,menutab,apps}'
 ExecStartPre=-runagent discover-smarthost
 ExecStartPre=/usr/local/bin/runagent discover-ldap
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/lemonldapng-app.pid \
@@ -47,6 +47,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lemonldapng-app.pid \
         --volume ./llng/auth:/usr/share/perl5/Lemonldap/NG/Portal/Auth/CustomAuth:Z \
         --volume ./llng/captcha:/usr/share/perl5/Lemonldap/NG/Portal/Captcha/CustomCaptcha:Z \
         --volume ./llng/menutab:/usr/share/perl5/Lemonldap/NG/Portal/MenuTab/CustomMenuTab:Z \
+        --volume .llng/apps:/usr/share/lemonldap-ng/portal/htdocs/static/common/apps:Z \
     ${LEMONLDAP_NG_IMAGE}
 ExecStartPost=/usr/local/bin/runagent update-smtp-settings
 ExecStartPost=/usr/local/bin/runagent update-ldap-settings

--- a/imageroot/systemd/user/lemonldapng-app.service
+++ b/imageroot/systemd/user/lemonldapng-app.service
@@ -47,7 +47,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lemonldapng-app.pid \
         --volume ./llng/auth:/usr/share/perl5/Lemonldap/NG/Portal/Auth/CustomAuth:Z \
         --volume ./llng/captcha:/usr/share/perl5/Lemonldap/NG/Portal/Captcha/CustomCaptcha:Z \
         --volume ./llng/menutab:/usr/share/perl5/Lemonldap/NG/Portal/MenuTab/CustomMenuTab:Z \
-        --volume .llng/apps:/usr/share/lemonldap-ng/portal/htdocs/static/common/apps:Z \
+        --volume ./llng/apps:/usr/share/lemonldap-ng/portal/htdocs/static/common/apps:Z \
     ${LEMONLDAP_NG_IMAGE}
 ExecStartPost=/usr/local/bin/runagent update-smtp-settings
 ExecStartPost=/usr/local/bin/runagent update-ldap-settings

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -41,7 +41,8 @@
     "host_format": "Must be a valid fully qualified domain name",
     "choose_the_ldap_domain_to_authenticate_users": "Choose the LDAP domain to authenticate users",
     "choose_ldap_domain": "Choose LDAP domain",
-    "ldap_domain": "LDAP domain"
+    "ldap_domain": "LDAP domain",
+    "lemonldapng_fqdn_tooltip": "The hostname (FQDN) of the lemonldapng webapp, can be set only once, use lemonldapng UI to change it"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -23,16 +23,23 @@
       <cv-column>
         <cv-tile light>
           <cv-form @submit.prevent="configureModule">
-            <cv-text-input
+            <NsTextInput
               :label="$t('settings.lemonldapng_fqdn')"
               placeholder="lemonldapng.example.org"
               v-model.trim="host"
               class="mg-bottom"
               :invalid-message="$t(error.host)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="
+                loading.getConfiguration ||
+                loading.configureModule ||
+                configured
+              "
               ref="host"
             >
-            </cv-text-input>
+              <template #tooltip>{{
+                $t("settings.lemonldapng_fqdn_tooltip")
+              }}</template>
+            </NsTextInput>
             <cv-toggle
               value="letsEncrypt"
               :label="$t('settings.lets_encrypt')"
@@ -145,6 +152,7 @@ export default {
       },
       urlCheckInterval: null,
       host: "",
+      configured: false,
       isLetsEncryptEnabled: false,
       isHttpToHttpsEnabled: true,
       ldap_domain: "",
@@ -226,6 +234,7 @@ export default {
       this.host = config.host;
       this.isLetsEncryptEnabled = config.lets_encrypt;
       this.isHttpToHttpsEnabled = config.http2https;
+      this.configured = config.configured;
       // force to reload value after dom update
       this.$nextTick(() => {
         this.ldap_domain = config.ldap_domain;


### PR DESCRIPTION
Add an 'apps' directory to the service's ExecStartPre command and update volume mapping. Configure Traefik host and HTTP port, and improve the UI with a tooltip for the FQDN setting.