### PR TITLE
Remove redundant Traefik route configurations from module scripts

### DIFF
--- a/imageroot/actions/configure-module/20configure_traefik
+++ b/imageroot/actions/configure-module/20configure_traefik
@@ -57,39 +57,6 @@ response = agent.tasks.run(
         'lets_encrypt': le
     },
 )
-response = agent.tasks.run(
-    agent_id=agent.resolve_agent_id('traefik@node'),
-    action='set-route',
-    data={
-        'instance': 'reload-'+os.environ['MODULE_ID'],
-        'url':  'http://127.0.0.1:' + os.environ["TCP_PORT"],
-        'host': 'reload.'+host,
-        'http2https': h2hs,
-        'lets_encrypt': le
-    },
-)
-response = agent.tasks.run(
-    agent_id=agent.resolve_agent_id('traefik@node'),
-    action='set-route',
-    data={
-        'instance': 'test1-'+os.environ['MODULE_ID'],
-        'url':  'http://127.0.0.1:' + os.environ["TCP_PORT"],
-        'host': 'test1.'+host,
-        'http2https': h2hs,
-        'lets_encrypt': le
-    },
-)
-response = agent.tasks.run(
-    agent_id=agent.resolve_agent_id('traefik@node'),
-    action='set-route',
-    data={
-        'instance': 'test2-'+os.environ['MODULE_ID'],
-        'url':  'http://127.0.0.1:' + os.environ["TCP_PORT"],
-        'host': 'test2.'+host,
-        'http2https': h2hs,
-        'lets_encrypt': le
-    },
-)
 
 # Check if traefik configuration has been successfull
 agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/destroy-module/20destroy
+++ b/imageroot/actions/destroy-module/20destroy
@@ -46,30 +46,6 @@ response = agent.tasks.run(
         'instance': 'manager-' + os.environ['MODULE_ID']
     },
 )
-# Remove traefik route
-response = agent.tasks.run(
-    agent_id=default_traefik_id,
-    action='delete-route',
-    data={
-        'instance': 'reload-' + os.environ['MODULE_ID']
-    },
-)
-# Remove traefik route
-response = agent.tasks.run(
-    agent_id=default_traefik_id,
-    action='delete-route',
-    data={
-        'instance': 'test1-' + os.environ['MODULE_ID']
-    },
-)
-# Remove traefik route
-response = agent.tasks.run(
-    agent_id=default_traefik_id,
-    action='delete-route',
-    data={
-        'instance': 'test2-' + os.environ['MODULE_ID']
-    },
-)
 
 # Check if traefik configuration has been successfull
 agent.assert_exp(response['exit_code'] == 0)


### PR DESCRIPTION
Eliminate unnecessary Traefik route setup and teardown commands to streamline module configuration processes.