### PR TITLE
Add retry mechanism for lemonldap-ng is-active in configuration retrieval

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -15,6 +15,7 @@ import json
 import agent
 from agent.ldapproxy import Ldapproxy
 import subprocess
+import time
 
 # Prepare return variable
 config = {}
@@ -52,6 +53,28 @@ if service_status != "active":
     config['cda_status'] = False
     config['saml_status'] = False
 else:
+    # Wait for the  lemonldapng-app command to succeed (timeout: 30 seconds)
+    timeout = 30  # seconds
+    interval = 1  # seconds between retries
+    elapsed_time = 0
+
+    # Check if lemonldapng-app is running
+    while elapsed_time < timeout:
+        command = ["systemctl", "is-active", "--user", "lemonldapng-app"]
+        try:
+            result = subprocess.run(command, stderr=subprocess.DEVNULL, stdout=subprocess.PIPE, text=True, check=True)
+            output = result.stdout.strip()
+            if output == 'active':  # If the command succeeds and returns output, break the loop
+                break
+        except subprocess.CalledProcessError:
+            # Print a message to stderr and wait before retrying
+            print("Waiting for lemonldapng-app to become available...", file=sys.stderr)
+            time.sleep(interval)
+            elapsed_time += interval
+            if elapsed_time >= timeout:
+                print("Timout is reached. lemonldapng-app is not available.", file=sys.stderr)
+                # Exit with an error code   
+                sys.exit(1)
     # retrieve the cross domain authentication value
     command = [
         "podman", "exec", "lemonldapng-app",


### PR DESCRIPTION
This pull request includes changes to the `imageroot/actions/get-configuration/20read` file to improve the handling of the `lemonldapng-app` service status check. The most important changes include adding a retry mechanism for checking the service status and importing the `time` module to support this functionality.

Enhancements to service status check:

* [`imageroot/actions/get-configuration/20read`](diffhunk://#diff-779d5d1173c31945ab1682949b9790fa57a8f438bf44880ec1b4dd21aacfc9a3R56-R77): Added a retry mechanism with a timeout of 30 seconds and an interval of 1 second between retries to check if `lemonldapng-app` is active. This ensures the script waits for the service to become available before proceeding.

Codebase updates:

* [`imageroot/actions/get-configuration/20read`](diffhunk://#diff-779d5d1173c31945ab1682949b9790fa57a8f438bf44880ec1b4dd21aacfc9a3R18): Imported the `time` module to support the new retry mechanism for checking the service status.